### PR TITLE
Update Configuration.php

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,14 +17,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('google_analytics_api');
+        $treeBuilder = new TreeBuilder('google_analytics_api');
 
-        $rootNode
+        $treeBuilder
+            ->getRootNode()
             ->children()
             ->scalarNode('google_analytics_json_key')
-            ->end()
-        ;
+            ->end();
 
         return $treeBuilder;
     }


### PR DESCRIPTION
The "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method called for the "google_analytics_api" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.