### PR TITLE
Fix 'metric alias repeated' exceptions

### DIFF
--- a/Service/GoogleAnalyticsService.php
+++ b/Service/GoogleAnalyticsService.php
@@ -110,7 +110,7 @@ class GoogleAnalyticsService {
 
         if (isset($metrics) && is_array($metrics)) {
 
-            $this->reportingDimensions = [];
+            $this->reportingMetrics = [];
 
             foreach ($metrics as $metric) {
 


### PR DESCRIPTION
Clear the correct variable so repeated calls to `getDataDateRangeMetricsDimensions()` do not fail because the previous data was still in place.